### PR TITLE
Adding checks and disconnect for AzureAD

### DIFF
--- a/Source/install.ps1
+++ b/Source/install.ps1
@@ -12,7 +12,7 @@ if ($env:PROCESSOR_ARCHITEW6432 -eq "AMD64") {
 # Starting transcript
 Start-Transcript -Path "$($env:TEMP)\IntuneSignatureManagerForOutlook-log.txt" -Force
 
-# Install NuGet Package Provider if it isn't installed
+# Install NuGet Package Provider if it isn't installed yet
 if ($NULL -eq (Get-PackageProvider -ListAvailable | Where-Object Name -eq NuGet)) {
     try {
         Install-PackageProvider -Name NuGet -Confirm:$False -Force -Scope CurrentUser
@@ -23,7 +23,7 @@ if ($NULL -eq (Get-PackageProvider -ListAvailable | Where-Object Name -eq NuGet)
     }
 }
 
-# Install AzureAD module to retrieve the user information if it doesn't exist
+# Install AzureAD module to retrieve the user information if it is not installed yet
 if (-not(Get-Module -ListAvailable -Name AzureAd)){
     Install-Module -Name AzureAD -Scope CurrentUser -Force
 }


### PR DESCRIPTION
As this is a wonderful little script I have added some little improvements.

- Added checks to see if NuGet and AzureAD are already available, if not install them. This makes the script a little faster if you are trying things out locally without needing to install both modules over and over if they are already installed.
- Added Disconnect-AzureAD to not keep the session open then needed